### PR TITLE
fix `Box<RenderBox + Send>` not implementing `RenderOnce`

### DIFF
--- a/src/render.rs
+++ b/src/render.rs
@@ -69,7 +69,6 @@ pub trait RenderBox {
     fn size_hint_box(&self) -> usize;
 }
 
-
 impl<T> RenderBox for T
     where T: RenderOnce
 {
@@ -85,6 +84,18 @@ impl<T> RenderBox for T
 // Box<RenderBox>
 
 impl<'b> RenderOnce for Box<RenderBox + 'b> {
+    #[inline]
+    fn render_once(self, tmpl: &mut TemplateBuffer) {
+        RenderBox::render_box(self, tmpl);
+    }
+
+    #[inline]
+    fn size_hint(&self) -> usize {
+        RenderBox::size_hint_box(self)
+    }
+}
+
+impl<'b> RenderOnce for Box<RenderBox + 'b + Send> {
     #[inline]
     fn render_once(self, tmpl: &mut TemplateBuffer) {
         RenderBox::render_box(self, tmpl);
@@ -117,6 +128,25 @@ impl<'b> RenderMut for Box<RenderMut + 'b> {
     }
 }
 
+impl<'b> RenderOnce for Box<RenderMut + 'b + Send> {
+    #[inline]
+    fn render_once(mut self, tmpl: &mut TemplateBuffer) {
+        RenderMut::render_mut(&mut *self, tmpl);
+    }
+
+    #[inline]
+    fn size_hint(&self) -> usize {
+        RenderMut::size_hint(&**self)
+    }
+}
+
+impl<'b> RenderMut for Box<RenderMut + 'b + Send> {
+    #[inline]
+    fn render_mut<'a>(&mut self, tmpl: &mut TemplateBuffer<'a>) {
+        RenderMut::render_mut(&mut **self, tmpl);
+    }
+}
+
 // Box<Render>
 
 impl<'b> RenderOnce for Box<Render + 'b> {
@@ -139,6 +169,32 @@ impl<'b> RenderMut for Box<Render + 'b> {
 }
 
 impl<'b> Render for Box<Render + 'b> {
+    #[inline]
+    fn render<'a>(&self, tmpl: &mut TemplateBuffer<'a>) {
+        Render::render(&**self, tmpl);
+    }
+}
+
+impl<'b> RenderOnce for Box<Render + 'b + Send> {
+    #[inline]
+    fn render_once(self, tmpl: &mut TemplateBuffer) {
+        Render::render(&*self, tmpl);
+    }
+
+    #[inline]
+    fn size_hint(&self) -> usize {
+        Render::size_hint(&**self)
+    }
+}
+
+impl<'b> RenderMut for Box<Render + 'b + Send> {
+    #[inline]
+    fn render_mut<'a>(&mut self, tmpl: &mut TemplateBuffer<'a>) {
+        Render::render(&*self, tmpl);
+    }
+}
+
+impl<'b> Render for Box<Render + 'b + Send> {
     #[inline]
     fn render<'a>(&self, tmpl: &mut TemplateBuffer<'a>) {
         Render::render(&**self, tmpl);

--- a/tests/boxes.rs
+++ b/tests/boxes.rs
@@ -1,0 +1,13 @@
+#[macro_use]
+extern crate horrorshow;
+
+use horrorshow::{Template, RenderBox};
+
+
+#[test]
+#[allow(unused_variables)]
+fn test_box_render_once_send() {
+    let x: Box<RenderBox + Send> = Box::new(html!{});
+    let mut v = Vec::new();
+    x.write_to_io(&mut v).unwrap();
+}


### PR DESCRIPTION
edited on github, let's see what travis says :)

right now if I have a `Box<RenderBox + Send>` i need to coerce it to a `Box<RenderBox>` before it becomes useful. Not that that's a blocker, but it's annoying.