### PR TITLE
Added missing pub in template macro definition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,8 @@ keywords = ["html", "template"]
 license = "MIT/Apache-2.0"
 
 [dev-dependencies]
-maud = "0.13" # target: nightly
-maud_macros = "0.13" # target: nightly
+maud = "0.14" # target: nightly
+maud_macros = "0.14" # target: nightly
 
 [features]
 default = ["ops"]

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -329,7 +329,7 @@ macro_rules! template {
         template!($($rest)*);
     };
     (pub $name:ident ($($field:ident : &$typ:ty),*) { $($tmpl:tt)* } $($rest:tt)*) => {
-        struct $name<'a> { $( $field: &'a $typ),* }
+        pub struct $name<'a> { $( $field: &'a $typ),* }
         impl<'a> $name<'a> {
             pub fn new($($field: &'a $typ),*) -> Self {
                 $name { $( $field: $field),* }

--- a/tests/template.rs
+++ b/tests/template.rs
@@ -22,3 +22,17 @@ fn test_template() {
     }.into_string().unwrap(), "<span><span>32</span></span>");
 }
 
+
+mod submodule {
+  template! {
+     pub Test3(num: &u64) {
+        div : num
+     }
+  }
+}
+
+#[test]
+fn test_template_in_module() {
+   assert_eq!(html! {p : submodule::Test3::new(&42)}.into_string().unwrap(), "<p><div>42</div></p>");
+}
+


### PR DESCRIPTION
When creating a template in a submodule, the `pub` qualifier wasn't transferred to the generated struct object.
I added a test in tests/templates.rs that would have failed without the fix.

I also version bumped the maud dependency, as it would not compile on the latest nightly rustc.


Thanks for making this great library!