### PR TITLE
Add "template-engine" category to crate metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ authors = ["Steven Allen <steven@stebalien.com>"]
 documentation = "https://docs.rs/horrorshow"
 repository = "https://github.com/Stebalien/horrorshow-rs"
 keywords = ["html", "template"]
+categories = ["template-engine"]
 license = "MIT/Apache-2.0"
 
 [features]


### PR DESCRIPTION
This might make it easier to find/compare to similar crates.