### PR TITLE
feat: add basic XML support

### DIFF
--- a/tests/xml.rs
+++ b/tests/xml.rs
@@ -1,0 +1,36 @@
+#![cfg(feature = "alloc")]
+
+use horrorshow::Template;
+
+#[macro_use]
+extern crate horrorshow;
+
+#[test]
+fn test_xml_close() {
+    assert_eq!(
+        xml! {
+            root {
+                link(href = "foobar");
+            }
+        }
+        .into_string()
+        .unwrap(),
+        "<root><link href=\"foobar\"/></root>",
+    );
+}
+
+#[test]
+fn test_xml_bool_attr() {
+    assert_eq!(
+        xml! {
+            root {
+                first(attr);
+                second(attr ?= true);
+                second(attr ?= false);
+            }
+        }
+        .into_string()
+        .unwrap(),
+        "<root><first attr=\"attr\"/><second attr=\"attr\"/><second/></root>",
+    );
+}


### PR DESCRIPTION
This adds an `xml!` macro mirroring the `html!` macro. It still uses the regular render traits so there's no HTML/XML type checking, but it's still convenient.